### PR TITLE
docs(BUILDING): URL fix for OpenLane 2 with Nix installation

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -9,7 +9,7 @@ export PDK=ihp-sg13g2
 export TT_CONFIG=ihp-sg13g2.yaml
 ```
 
-Then install OpenLane 2 with Nix, as explained [here](https://openlane2.readthedocs.io/en/latest/getting_started/nix_installation/index.html).
+Then install OpenLane 2 with Nix, as explained [here](https://openlane2.readthedocs.io/en/latest/getting_started/common/nix_installation/index.html).
 
 ## Repository setup
 


### PR DESCRIPTION
updated the old URL for OpenLane 2 with Nix installation to new one old URL: https://openlane2.readthedocs.io/en/latest/getting_started/nix_installation/index.html

updated URL: 
https://openlane2.readthedocs.io/en/latest/getting_started/common/nix_installation/index.html