### PR TITLE
feat: update datasheet and ensure gds workflow isn't broken

### DIFF
--- a/.github/workflows/gds.yaml
+++ b/.github/workflows/gds.yaml
@@ -105,8 +105,8 @@ jobs:
       - name: Copy final results
         run: python ./tt/configure.py --copy-final-results
 
-      - name: Create IHP submission
-        run: python ./tt/configure.py --create-ihp-submission
+      - name: Create foundry submission directory
+        run: python ./tt/configure.py --create-foundry-submission
 
       - name: upload GDS artifact
         if: success() || failure()
@@ -148,15 +148,15 @@ jobs:
 
       - name: Rename top-level cell for IHP submission, convert to OAS
         run: |
-          python fill/rename.py ihp/gds/tt_ihp_wrapper_final.gds ihp/gds/FMD_QNC_$SHUTTLE_SLUG.gds FMD_QNC_$SHUTTLE_SLUG
-          strm2oas ihp/gds/FMD_QNC_$SHUTTLE_SLUG.gds ihp/gds/FMD_QNC_$SHUTTLE_SLUG.oas
+          python fill/rename.py foundry_submission/gds/tt_ihp_wrapper_final.gds foundry_submission/gds/FMD_QNC_$SHUTTLE_SLUG.gds FMD_QNC_$SHUTTLE_SLUG
+          strm2oas foundry_submission/gds/FMD_QNC_$SHUTTLE_SLUG.gds foundry_submission/gds/FMD_QNC_$SHUTTLE_SLUG.oas
 
-      - name: upload IHP submission directory
+      - name: upload foundry submission directory
         uses: actions/upload-artifact@v4
         if: success() || failure()
         with:
-          name: ihp_submission
-          path: ihp
+          name: foundry_submission
+          path: foundry_submission
 
       # Install iverilog, cocotb (required for GL test)
       - name: install oss-cad-suite
@@ -171,7 +171,7 @@ jobs:
           EXPECTED_REPO: ${{ github.repository }}
         run: |
           # temporary workaround for missing bits in pad_raw:
-          sed -i 's/inout \[49:0\] pad_raw/inout [63:0] pad_raw/' ../../../ihp/verilog/gl/tt_ihp_wrapper.nl.v
+          sed -i 's/inout \[49:0\] pad_raw/inout [63:0] pad_raw/' ../../../foundry_submission/verilog/gl/tt_ihp_wrapper.nl.v
 
           make clean test_mux_gl
           # make will return success even if the test fails, so check for failure in the results.xml

--- a/.github/workflows/gds.yaml
+++ b/.github/workflows/gds.yaml
@@ -78,7 +78,7 @@ jobs:
           done
 
       - name: Harden Chip ROM
-        run: nix-shell $GITHUB_WORKSPACE/librelane/shell.nix --run "python -m librelane --pdk-root $PDK_ROOT --manual-pdk --pdk $PDK tt/rom/config_ihp.json"
+        run: nix-shell $GITHUB_WORKSPACE/librelane/shell.nix --run "python -m librelane --pdk-root $PDK_ROOT --manual-pdk --pdk $PDK tt/rom/config.json"
 
       - name: Harden tt_ctrl
         working-directory: tt-multiplexer/ol2/tt_ctrl

--- a/.github/workflows/precheck.yaml
+++ b/.github/workflows/precheck.yaml
@@ -40,7 +40,7 @@ jobs:
           workflow: gds.yaml
           run_id: ${{ github.event.workflow_run.id }}
           workflow_conclusion: success
-          name: ihp_submission
+          name: foundry_submission
           path: tinytapeout-submission
 
       - name: Run DRC check
@@ -98,7 +98,7 @@ jobs:
           workflow: gds.yaml
           run_id: ${{ github.event.workflow_run.id }}
           workflow_conclusion: success
-          name: ihp_submission
+          name: foundry_submission
           path: ihp
 
       - name: Run Density check

--- a/.github/workflows/tt_datasheet.yaml
+++ b/.github/workflows/tt_datasheet.yaml
@@ -29,13 +29,23 @@ jobs:
           cache: 'pip'
       - run: pip install -r tt/requirements.txt -r tt-multiplexer/py/requirements.txt
 
-      - name: Pandoc deps
+      - name: Install Pandoc
         run: |
           sudo apt-get update -y
-          sudo apt-get install -y pandoc texlive-xetex librsvg2-bin
+          sudo apt-get install -y pandoc
 
-      - name: Generate datasheet
-        run: python ./tt/configure.py --dump-markdown datasheet.md --dump-pdf datasheet.pdf
+      - name: Download assets
+        run: |
+          git clone https://github.com/TinyTapeout/tt-datasheet-artwork tt/docs/typst/resources/external
+          wget -P tt/docs/typst/resources/fonts https://github.com/google/fonts/raw/refs/heads/main/ofl/notocoloremoji/NotoColorEmoji-Regular.ttf
+
+      - name: Install Typst
+        uses: typst-community/setup-typst@v4
+        with:
+          typst-version: '0.13.1'
+
+      - name: Generate datasheet files
+        run: python ./tt/configure.py --build-datasheet
 
       - name: Check file existence and content
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,8 @@ datasheet.pdf
 shuttle_index.json
 shuttle_index.md
 
-ihp/
+# Auto generated foundry submission folder:
+foundry_submission/
 
 # pip-compile
 *.egg-info

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -36,7 +36,7 @@ python tt/configure.py --update-shuttle
 ## Harden
 
 ```bash
-nix-shell ${LIBRELANE_ROOT}/shell.nix --run "python -m librelane --pdk-root $PDK_ROOT --manual-pdk --pdk $PDK tt/rom/config_ihp.json"
+nix-shell ${LIBRELANE_ROOT}/shell.nix --run "python -m librelane --pdk-root $PDK_ROOT --manual-pdk --pdk $PDK tt/rom/config.json"
 nix-shell ${LIBRELANE_ROOT}/shell.nix --run "cd tt-multiplexer/ol2/tt_ctrl && python build.py"
 nix-shell ${LIBRELANE_ROOT}/shell.nix --run "cd tt-multiplexer/ol2/tt_mux && python build.py"
 python tt/configure.py --copy-macros

--- a/config.yaml
+++ b/config.yaml
@@ -8,6 +8,18 @@ no_power_gating: false
 pdk: 'ihp-sg13g2'
 
 datasheet_config:
+
+  artwork:
+    - {id: TT_POCA_01_A, rotate: 90deg}
+    - {id: TT_POCA_01_B, rotate: 90deg}
+    - {id: TT_POCA_01_C, rotate: 90deg}
+    - {id: TT_POCA_01_D, rotate: -90deg}
+    - {id: TT_POCA_01_E, rotate: 90deg}
+    - {id: TT_POCA_01_F, rotate: 90deg}
+    - {id: TT_POCA_01_G, rotate: 90deg}
+    - {id: TT_POCA_01_H, rotate: -90deg}
+    - {id: TT_POCA_01_I, rotate: 90deg}
+
   include:
     - docs/chip_map.typ
     - docs/funding.typ

--- a/config.yaml
+++ b/config.yaml
@@ -6,3 +6,7 @@ top_level_macro: 'tt_ihp_wrapper'
 powered_netlists: false
 no_power_gating: false
 pdk: 'ihp-sg13g2'
+
+datasheet_config:
+  include:
+    - docs/chip_map.typ

--- a/config.yaml
+++ b/config.yaml
@@ -10,3 +10,4 @@ pdk: 'ihp-sg13g2'
 datasheet_config:
   include:
     - docs/chip_map.typ
+    - docs/funding.typ

--- a/docs/chip_map.typ
+++ b/docs/chip_map.typ
@@ -1,0 +1,6 @@
+#tt.datasheet.renders(
+  {
+    tt.datasheet.add_render("GDS", image("/docs/images/full_gds.png"))
+    tt.datasheet.add_render("Logic Density", image("/docs/images/logic_density.png"), subtitle: "Local Interconnect Layer")
+  }
+)

--- a/docs/funding.typ
+++ b/docs/funding.typ
@@ -1,0 +1,5 @@
+#tt.datasheet.funding[
+  IHP PDK support for Tiny Tapeout was funded by The SwissChips Initative.
+
+  The manufacturing of Tiny Tapeout IHP 25b silicon was funded by the German BMBF project FMD-QNC (16ME0831).
+]

--- a/fill/Makefile
+++ b/fill/Makefile
@@ -1,5 +1,5 @@
-SRC = ../ihp/gds/tt_ihp_wrapper.gds
-FINAL_GDS = ../ihp/gds/tt_ihp_wrapper_final.gds
+SRC = ../foundry_submission/gds/tt_ihp_wrapper.gds
+FINAL_GDS = ../foundry_submission/gds/tt_ihp_wrapper_final.gds
 TMP_DIR = tmp
 KLAYOUT_CMD ?= klayout
 

--- a/projects/tt_um_nefelimet_updown_cntr/info.yaml
+++ b/projects/tt_um_nefelimet_updown_cntr/info.yaml
@@ -27,7 +27,7 @@ pinout:
   ui[0]: "data_in[0]"
   ui[1]: "data_in[1]"
   ui[2]: "data_in[2]"
-  ui[3]: "rst_"
+  ui[3]: "rst\\_"
   ui[4]: "ld_cnt"
   ui[5]: "updn_cnt"
   ui[6]: "count_enb"

--- a/verilog/dv/mux/Makefile
+++ b/verilog/dv/mux/Makefile
@@ -9,7 +9,7 @@ else
 endif
 
 export USER_PROJECT_VERILOG := $(abspath ../../../verilog)
-export IHP_SUBMISSION = $(abspath ../../../ihp/)
+export FOUNDRY_SUBMISSION = $(abspath ../../../foundry_submission/)
 export TT_GL_VERILOG := $(abspath ../../../tt-multiplexer/ol2/tt_top/verilog/)
 
 SIM           ?= icarus

--- a/verilog/includes/includes.gl.mux_top
+++ b/verilog/includes/includes.gl.mux_top
@@ -1,4 +1,4 @@
--v $(IHP_SUBMISSION)/verilog/gl/tt_ihp_wrapper.nl.v
+-v $(FOUNDRY_SUBMISSION)/verilog/gl/tt_ihp_wrapper.nl.v
 -v $(TT_GL_VERILOG)/tt_ctrl.nl.v
 -v $(TT_GL_VERILOG)/tt_mux.nl.v
 -v $(TT_GL_VERILOG)/tt_um_chip_rom.nl.v

--- a/verilog/includes/includes.rtl.caravel_user_project
+++ b/verilog/includes/includes.rtl.caravel_user_project
@@ -1,7 +1,7 @@
 -v $(USER_PROJECT_VERILOG)/rtl/tt-multiplexer/ol2/tt_top/tt_ihp_wrapper.v
 -v $(USER_PROJECT_VERILOG)/../tt/logo/tt_logo_bottom.v
--v $(USER_PROJECT_VERILOG)/../tt/ihp/tt_logo_corner.v
 -v $(USER_PROJECT_VERILOG)/../tt/logo/tt_logo_top.v
+-v $(USER_PROJECT_VERILOG)/../tt/tech/ihp-sg13g2/tt_logo_corner.v
 -v $(USER_PROJECT_VERILOG)/rtl/tt-multiplexer/rtl/tt_top.v
 -v $(USER_PROJECT_VERILOG)/rtl/tt-multiplexer/rtl/tt_ctrl.v
 -v $(USER_PROJECT_VERILOG)/rtl/tt-multiplexer/rtl/tt_ihp_gpio.v


### PR DESCRIPTION
This PR updates the datasheet workflow and adds some commits from ttihp26a to ensure that the GDS workflow remains functional despite updating `tt-support-tools`.

I'll follow up with some light docs editing in another PR to make sure everything is at least presentable.