### PR TITLE
docs: tidy up project docs

### DIFF
--- a/docs/chip_map.typ
+++ b/docs/chip_map.typ
@@ -1,6 +1,6 @@
 #tt.datasheet.renders(
   {
     tt.datasheet.add_render("GDS", image("/docs/images/full_gds.png"))
-    tt.datasheet.add_render("Logic Density", image("/docs/images/logic_density.png"), subtitle: "Local Interconnect Layer")
+    tt.datasheet.add_render("Logic Density", image("/docs/images/logic_density.png"))
   }
 )

--- a/projects/tt_um_pqn/docs/info.md
+++ b/projects/tt_um_pqn/docs/info.md
@@ -9,13 +9,13 @@ You can also include images in this folder and reference them in the markdown. E
 
 ## How it Works
 
-This project is based on the PQN model [1], which is designed for the digital implementation of neuron circuits.  
+This project is based on the PQN model[^1], which is designed for the digital implementation of neuron circuits.  
 In particular, this work adopts a two-variation PQN model.  
-The parameters are configured to reproduce Class 1 and Class 2 neurons according to Hodgkin’s classification [2].
+The parameters are configured to reproduce Class 1 and Class 2 neurons according to Hodgkin’s classification[^2].
 
 ### Governing Equations
 
-Following [1], The neuron dynamics are defined as:
+Following footnote 1, The neuron dynamics are defined as:
 
 ```math
 \frac{dv}{dt} = \frac{\phi}{\tau} \left( f(v) - n + I_0 + k I_{\text{stim}} \right)
@@ -101,6 +101,7 @@ For the expanded coefficients used in implementation, please refer to the module
 ### Module Interface
 
 The ports usage of the top module is as follows:
+
 | Pins | Bits | Direction | Description |
 | --------------------------- | ---- | --------- | ------------------------------------ |
 | `clk` | 1 | Input | Clock signal |
@@ -110,8 +111,8 @@ The ports usage of the top module is as follows:
 | `ui_in[0]` | 1 | Input | Mode select input |
 | `uo_out[7:0], uio_out[7:0]` | 16 | Output | Signed 16-bit membrane voltage |
 
-[1] Nanami, T., & Kohno, T. (2023). Piecewise quadratic neuron model: A tool for close-to-biology spiking neuronal network simulation on dedicated hardware. Frontiers in Neuroscience, 16, 1069133.c  
-[2] Hodgkin, A. L. (1948). The local electric changes associated with repetitive action in a non-medullated axon. The Journal of physiology, 107(2), 165.
+[^1]: Nanami, T., & Kohno, T. (2023). Piecewise quadratic neuron model: A tool for close-to-biology spiking neuronal network simulation on dedicated hardware. Frontiers in Neuroscience, 16, 1069133.c  
+[^2]: Hodgkin, A. L. (1948). The local electric changes associated with repetitive action in a non-medullated axon. The Journal of physiology, 107(2), 165.
 
 ## How to Test
 

--- a/projects/tt_um_riscv_mini_ihp/docs/info.md
+++ b/projects/tt_um_riscv_mini_ihp/docs/info.md
@@ -11,7 +11,7 @@ You can also include images in this folder and reference them in the markdown. E
 
 This project implements _RISC-V Mini_ by RickGao (https://github.com/RickGao/RISC-V-Mini), a compact 8-bit RISC-V processor core optimized for Tiny Tapeout, a fabrication platform for small-scale educational IC projects. The processor employs a customized, compressed RISC-V instruction set (RVC) to reduce instruction width to 16 bits, leading to a more compact design suited to Tiny Tapeout's area and resource constraints. Developed in Verilog, this processor will handle computational, load/store and control-flow operations efficiently and undergo verification through simulation and testing.
 
-### Processor Components
+### Processor Components
 
 The processor comprises the following core components, optimized to meet Tiny Tapeout’s area requirements:
 
@@ -47,7 +47,7 @@ Simply set the input to the instruction and clock once to receive the output.
 | XOR    |      001       |       01       |    XXX     |   XXX     |   XXX    | Opcode(00) | 
 | SLT    |      111       |       00       |    XXX     |   XXX     |   XXX    | Opcode(00) | 
 
-#### I-Type
+#### I-Type
 
 | Name   | funct3 [15:13] | Imm [12:8] (5-bit unsigned) | rs1 [7:5] | rd [4:2] | Opcode(01) | 
 | ---- | -------------- | -------------- | ---------- | --------- | --- |
@@ -74,9 +74,3 @@ Simply set the input to the instruction and clock once to receive the output.
 | BEQ    |  011       |       00       |    XXX     |   XXX     |   000    | Opcode(11)| 
 | BNE    |      011       |       10       |    XXX     |   XXX     |   000    | Opcode(11)| 
 | BLT    |      111       |       00       |    XXX     |   XXX     |   000    | Opcode(11)| 
-
-
-
-## External hardware
-
-No external hardware.

--- a/projects/tt_um_rte_eink_driver/docs/info.md
+++ b/projects/tt_um_rte_eink_driver/docs/info.md
@@ -30,19 +30,18 @@ the e-ink display is not PMOD-compatible, it is necessary to install a header
 onto the e-ink display and create a bundle of jumper wires to connect to the
 PMOD as follows:
 
-pin     signal  direction  PMOD pin
-----------------------------------------------------------
-ECS:    uio[0]  output     1
-MOSI:   uio[1]  output     2
-MISO:   uio[2]  input      3
-SCK:    uio[3]  output     4
-SRCS:   uio[4]  output     7
-RST:    uio[5]  output     8
-BUSY:   uio[6]  input      9
-D/C:    uio[7]  output     10
-GND:                       11 or 5
-VIN:                       12 or 6
-----------------------------------------------------------
+| pin  | signal | direction | PMOD pin |
+| :--- | :----- | :-------- | :------- |
+| ECS  | uio[0] | output    | 1        |
+| MOSI | uio[1] | output    | 2        |
+| MISO | uio[2] | input     | 3        |
+| SCK  | uio[3] | output    | 4        |
+| SRCS | uio[4] | output    | 7        |
+| RST  | uio[5] | output    | 8        |
+| BUSY | uio[6] | input     | 9        |
+| D/C  | uio[7] | output    | 10       |
+| GND  |        |           | 11 or 5  |
+| VIN  |        |           | 12 or 8  |
 
 To test the eight example patterns, raise one of the input pins
 to value "1".  This can be done with a set of external buttons on

--- a/projects/tt_um_wokwi_434917143298726913/docs/info.md
+++ b/projects/tt_um_wokwi_434917143298726913/docs/info.md
@@ -10,6 +10,7 @@ You can also include images in this folder and reference them in the markdown. E
 ## How it works
 
 The project will work by modelling a chip design
+
 ## How to test
 
 The project will be used to see a model of the chip design in 3D

--- a/projects/tt_um_wokwi_434917171311441921/docs/info.md
+++ b/projects/tt_um_wokwi_434917171311441921/docs/info.md
@@ -10,9 +10,11 @@ You can also include images in this folder and reference them in the markdown. E
 ## How it works
 
 Inputs to LED number display experiment
+
 ## How to test
 
 dont use it. not good
+
 ## External hardware
 
 yes

--- a/projects/tt_um_wokwi_434917219039482881/docs/info.md
+++ b/projects/tt_um_wokwi_434917219039482881/docs/info.md
@@ -14,6 +14,7 @@ it works
 ## How to test
 
 TBD
+
 ## External hardware
 
 TBD

--- a/projects/tt_um_wokwi_434918311072808961/docs/info.md
+++ b/projects/tt_um_wokwi_434918311072808961/docs/info.md
@@ -10,9 +10,11 @@ You can also include images in this folder and reference them in the markdown. E
 ## How it works
 
 i DONT NOW
+
 ## How to test
 
 KLICK THE BOTTOM
+
 ## External hardware
 
 7 DIGTIS TEIL


### PR DESCRIPTION
Ref #108 

This PR lightly edits a handful of the project docs to fix formatting issues such as broken headings and tables.

It also removes the "Local interconnect layer" text for the logic density chip render -- not sure if it is accurate but I've opted to drop it.